### PR TITLE
Fix pv renaming errors

### DIFF
--- a/cp2800Sup/cp2800.db
+++ b/cp2800Sup/cp2800.db
@@ -38,7 +38,7 @@ record(calc, "$(P)COMMAND")
     field(INPA, "$(P)CMDRSP MS")
     field(SCAN, "1 second")
     field(PHAS, "2")
-    field(FLNK, "$(P)RSPF")
+    field(FLNK, "$(P)RSPF.PROC")
 }
 record(bi, "$(P)RESET_SINCE_POWER_FAIL")
 {
@@ -47,7 +47,7 @@ record(bi, "$(P)RESET_SINCE_POWER_FAIL")
     field(ZNAM, "No")
     field(ONAM, "Yes")
     field(OSV,  "MAJOR")
-    field(FLNK, "$(P)RSP")
+    field(FLNK, "$(P)RSP.PROC")
 }
 record(mbbi, "$(P)RESPONSE") 
 {

--- a/cp2800Sup/cp2800.db
+++ b/cp2800Sup/cp2800.db
@@ -17,7 +17,7 @@ record(bi, "$(P)DISABLE")
     field(PINI, "YES")
 }
 
-### CMDRSP 
+### COMMAND_RESPONSE 
 
 record(mbbiDirect, "$(P)COMMAND_RESPONSE") 
 {
@@ -26,7 +26,7 @@ record(mbbiDirect, "$(P)COMMAND_RESPONSE")
 record(calcout,"$(P):CLEAR_RESPONSE")
 {
     field(DESC, "Clear Response")
-    field(OUT,  "$(P)CMDRSP PP")
+    field(OUT,  "$(P)COMMAND_RESPONSE PP")
     field(CALC, "A")
     field(INPA, "1")
     field(PINI, "YES")
@@ -35,25 +35,25 @@ record(calc, "$(P)COMMAND")
 {
     field(DESC, "Command")
     field(CALC, "A>>4")
-    field(INPA, "$(P)CMDRSP MS")
+    field(INPA, "$(P)COMMAND_RESPONSE MS")
     field(SCAN, "1 second")
     field(PHAS, "2")
-    field(FLNK, "$(P)RSPF.PROC")
+    field(FLNK, "$(P)RESET_SINCE_POWER_FAIL.PROC")
 }
 record(bi, "$(P)RESET_SINCE_POWER_FAIL")
 {
     field(DESC, "Reset since ack power fail")
-    field(INP,  "$(P)CMDRSP.B3 MS")
+    field(INP,  "$(P)COMMAND_RESPONSE.B3 MS")
     field(ZNAM, "No")
     field(ONAM, "Yes")
     field(OSV,  "MAJOR")
-    field(FLNK, "$(P)RSP.PROC")
+    field(FLNK, "$(P)RESPONSE.PROC")
 }
 record(mbbi, "$(P)RESPONSE") 
 {
     field(DESC, "Response")
     field(DTYP, "Raw Soft Channel")
-    field(INP,  "$(P)CMDRSP MS")
+    field(INP,  "$(P)COMMAND_RESPONSE MS")
     field(NOBT, "3")
     field(SHFT, "0")
     field(UNSV, "INVALID")

--- a/cp2800Sup/cp2800.db
+++ b/cp2800Sup/cp2800.db
@@ -23,7 +23,7 @@ record(mbbiDirect, "$(P)COMMAND_RESPONSE")
 {
     field(DESC, "Command Response")
 }
-record(calcout,"$(P):CLEAR_RESPONSE")
+record(calcout,"$(P)CLEAR_RESPONSE")
 {
     field(DESC, "Clear Response")
     field(OUT,  "$(P)COMMAND_RESPONSE PP")

--- a/cp2800Sup/cp2800.proto
+++ b/cp2800Sup/cp2800.proto
@@ -47,7 +47,7 @@ test { out "%s%1!"; in "%1!%40c"; }
 #
 # Extract the CMD_RSP byte on mismatch
 #
-@mismatch  { in "%1!" STX $ADR "%(\$1CMDRSP.VAL)01r%*30c"; }
+@mismatch  { in "%1!" STX $ADR "%(\$1COMMAND_RESPONSE.VAL)01r%*30c"; }
 
 # This a binary communications protocol, which described in the CP2800 Compressors wiki page.
 


### PR DESCRIPTION
When PV names were made more verbose in the past it broke functionality because they weren't renamed anywhere. This fixes that, and 2 FLNKs.